### PR TITLE
Allow aborted upgrades to fail gracefully

### DIFF
--- a/templates/deb/postrm_upgrade.sh.erb
+++ b/templates/deb/postrm_upgrade.sh.erb
@@ -42,7 +42,7 @@ then
     # 'apt-get purge' runs 'on remove' section, then this section.
     # There is no equivalent in RPM or ARCH.
     after_purge
-elif [ "${1}" = "upgrade" ]
+elif [ "${1}" = "upgrade" -o "${1}" = "abort-upgrade" ]
 then
     # This represents the case where the old package's postrm is called after
     # the 'preinst' script is called.


### PR DESCRIPTION
Without this, `abort-upgrade` (due to a non-zero exit code from a before-upgrade script)
also fails the postrm script, which leaves the debian package in an error state, rather than
simply aborting the upgrade.